### PR TITLE
[library/common] fix: error in fail function on unsupported vpn types

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 0.2.1
+version: 0.2.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - common
@@ -13,6 +13,8 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
+    - kind: fixed
+      description: Fix deprecation warning on unsupported vpn types.
     - kind: fixed
       description: Make sure service.monitor is optional.
     - kind: removed

--- a/charts/library/common/templates/addons/vpn/_vpn.tpl
+++ b/charts/library/common/templates/addons/vpn/_vpn.tpl
@@ -5,11 +5,11 @@ It will include / inject the required templates based on the given values.
 {{- define "common.addon.vpn" -}}
 {{- if .Values.addons.vpn.enabled -}}
   {{- if eq "openvpn" .Values.addons.vpn.type -}}
-    {{- fail "The 'openvpn' VPN type is no longer supported. Please migrate to the 'gluetun' type." . }}
+    {{- fail "The 'openvpn' VPN type is no longer supported. Please migrate to the 'gluetun' type." }}
   {{- end -}}
 
   {{- if eq "wireguard" .Values.addons.vpn.type -}}
-    {{- fail "The 'wireguard' VPN type is no longer supported. Please migrate to the 'gluetun' type." . }}
+    {{- fail "The 'wireguard' VPN type is no longer supported. Please migrate to the 'gluetun' type." }}
   {{- end -}}
 
   {{- if eq "gluetun" .Values.addons.vpn.type -}}


### PR DESCRIPTION
**Description of the change**

The deprecation warning for the removal of the `wireguard` and `openvpn` VPNs includes a syntax error, which makes it error like this:

```
_vpn.tpl:12:8: executing "common.addon.vpn" at <fail>: wrong number of args for fail: want 1 got 2
```

This PR fixes the syntax error, so that it errors nicely like this, instead:

```
 The 'wireguard' VPN type is no longer supported. Please migrate to the 'gluetun' type.
```

**Benefits**

Users migrating from the old k8s-at-home library chart are not confused by the error

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
