### PR TITLE
feat(common): Allow services to use extra keys in selector

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 0.2.2
+version: 0.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - common
@@ -13,7 +13,5 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: Fix deprecation warning on unsupported vpn types.
     - kind: changed
-      description: Updated code-server image to v4.7.1
+      description: Support services have extraSelectorLabels

--- a/charts/library/common/templates/classes/_service.tpl
+++ b/charts/library/common/templates/classes/_service.tpl
@@ -95,6 +95,7 @@ spec:
     {{ end }}
   {{- end }}
   {{- end }}
-  selector:
-    {{- include "common.labels.selectorLabels" . | nindent 4 }}
+  {{- with (merge ($values.extraSelectorLabels | default dict) (include "common.labels.selectorLabels" . | fromYaml)) }}
+  selector: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -320,6 +320,9 @@ service:
         # [[ref]](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
         nodePort:
 
+        # -- Allow adding additional match labels
+        extraSelectorLabels: {}
+
 # -- Configure the ingresses for the chart here.
 # Additional ingresses can be added by adding a dictionary key similar to the 'main' ingress.
 # @default -- See below


### PR DESCRIPTION
**Description of the change**

Allow services to use extra keys in selector

**Benefits**

authentik helm chart overrides the deployment template, and adds a component label. https://github.com/goauthentik/helm/blob/main/charts/authentik/templates/deployment.yaml#L19

This fix allows the service to target just the server instaed of both. recent versions of nginx ingress have trouble with selector label matches a pod with no ports (which the overridded template did)

**Possible drawbacks**

since it parses, merges, then to yaml again, it should just work. Nothing else I could think of wouldn't be a breaking change.

**Applicable issues**

see authentik helm chart

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
