### PR TITLE
feat(common): add support for gateway api routes

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.0.1
+version: 1.1.0
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -14,27 +14,5 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
-    - kind: removed
-      description: "**BREAKING**: Removed support for HorizontalPodAutoscaler"
-    - kind: added
-      description: Added support for `httpGet` probes
-    - kind: added
-      description: Added support for setting labels / annotations on volumeClaimTemplates
-    - kind: added
-      description: Support services have extraSelectorLabels
     - kind: changed
-      description: "**BREAKING**: Restructure of template components. All Helm template names have changed!"
-    - kind: changed
-      description: "**BREAKING**: Raised minimum supported k8s version to 1.22"
-    - kind: changed
-      description: "**BREAKING**: Renamed `configmap` key to `configMaps`"
-    - kind: changed
-      description: "**BREAKING**: Moved `serviceMonitor` from `service` to its own key"
-    - kind: changed
-      description: "**BREAKING**: Renamed `secret` key to `secrets`, which now works similar to `configMaps`"
-    - kind: changed
-      description: Updated code-server image to v4.8.2
-    - kind: changed
-      description: Updated gluetun image to v3.32.0
-    - kind: fixed
-      description: Fix NOTES always showing ingress protocol as http
+      description: Added support for Gateway API Routes

--- a/charts/library/common/templates/_route.tpl
+++ b/charts/library/common/templates/_route.tpl
@@ -1,0 +1,17 @@
+{{/* Renders the Route objects required by the chart */}}
+{{- define "common.route" -}}
+  {{- /* Generate named routes as required */ -}}
+  {{- range $name, $route := .Values.route }}
+    {{- if $route.enabled -}}
+      {{- $routeValues := $route -}}
+
+      {{/* set defaults */}}
+      {{- if not $routeValues.nameOverride -}}
+        {{- $_ := set $routeValues "nameOverride" $name -}}
+      {{- end -}}
+
+      {{- $_ := set $ "ObjectValues" (dict "route" $routeValues) -}}
+      {{- include "common.classes.route" $ | nindent 0 -}}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -1,0 +1,72 @@
+
+{{/*
+This template serves as a blueprint for all Route objects that are created
+within the common library.
+*/}}
+{{- define "common.classes.route" -}}
+{{- $values := .Values.route -}}
+{{- if hasKey . "ObjectValues" -}}
+  {{- with .ObjectValues.route -}}
+    {{- $values = . -}}
+  {{- end -}}
+{{ end -}}
+
+{{- $fullName := include "common.names.fullname" . -}}
+{{- if and (hasKey $values "nameOverride") $values.nameOverride -}}
+  {{- $fullName = printf "%v-%v" $fullName $values.nameOverride -}}
+{{ end -}}
+{{- $routeKind := $values.kind | default "HTTPRoute" -}}
+{{- $primaryService := get .Values.service (include "common.service.primary" .) -}}
+{{- $defaultServiceName := $fullName -}}
+{{- if and (hasKey $primaryService "nameOverride") $primaryService.nameOverride -}}
+  {{- $defaultServiceName = printf "%v-%v" $defaultServiceName $primaryService.nameOverride -}}
+{{- end -}}
+{{- $defaultServicePort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+{{- if and (ne $routeKind "GRPCRoute") (ne $routeKind "HTTPRoute") (ne $routeKind "TCPRoute") (ne $routeKind "TLSRoute") (ne $routeKind "UDPRoute") }}
+  {{- fail (printf "Not a valid route kind (%s)" $routeKind) }}
+{{- end }}
+kind: {{ $routeKind }}
+metadata:
+  name: {{ $fullName }}
+  {{- with (merge ($values.labels | default dict) (include "common.labels" $ | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with (merge ($values.annotations | default dict) (include "common.annotations" $ | fromYaml)) }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- range $values.parentRefs }}
+    - group: {{ default "gateway.networking.k8s.io" .group }}
+      kind: {{ default "Gateway" .kind }}
+      name: {{ required (printf "parentRef name is required for %v %v" $routeKind $fullName) .name }}
+      namespace: {{ required (printf "parentRef namespace is required for %v %v" $routeKind $fullName) .namespace }}
+      sectionName: {{ default "" .sectionName | quote}}
+  {{- end }}
+  {{- if and (ne $routeKind "TCPRoute") (ne $routeKind "UDPRoute") $values.hostnames }}
+  hostnames:
+  {{- with $values.hostnames }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range $values.rules }}
+  - backendRefs:
+    {{- range .backendRefs }}
+    - group: {{ default "" .group | quote}}
+      kind: {{ default "Service" .kind }}
+      name: {{ default $defaultServiceName .name }}
+      namespace: {{ default $.Release.Namespace .namespace }}
+      port: {{ default $defaultServicePort.port .port }}
+      weight: {{ default 1 .weight }}
+    {{- end }}
+    {{- if (eq $routeKind "HTTPRoute") }}
+      {{- with .matches }}
+    matches:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -1,4 +1,3 @@
-
 {{/*
 This template serves as a blueprint for all Route objects that are created
 within the common library.

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -2,7 +2,7 @@
 This template serves as a blueprint for all Route objects that are created
 within the common library.
 */}}
-{{- define "common.classes.route" -}}
+{{- define "bjw-s.common.class.route" -}}
 {{- $values := .Values.route -}}
 {{- if hasKey . "ObjectValues" -}}
   {{- with .ObjectValues.route -}}
@@ -10,17 +10,17 @@ within the common library.
   {{- end -}}
 {{ end -}}
 
-{{- $fullName := include "common.names.fullname" . -}}
+{{- $fullName := include "bjw-s.common.lib.chart.names.fullname" . -}}
 {{- if and (hasKey $values "nameOverride") $values.nameOverride -}}
   {{- $fullName = printf "%v-%v" $fullName $values.nameOverride -}}
 {{ end -}}
 {{- $routeKind := $values.kind | default "HTTPRoute" -}}
-{{- $primaryService := get .Values.service (include "common.service.primary" .) -}}
+{{- $primaryService := get .Values.service (include "bjw-s.common.lib.service.primary" .) -}}
 {{- $defaultServiceName := $fullName -}}
 {{- if and (hasKey $primaryService "nameOverride") $primaryService.nameOverride -}}
   {{- $defaultServiceName = printf "%v-%v" $defaultServiceName $primaryService.nameOverride -}}
 {{- end -}}
-{{- $defaultServicePort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
+{{- $defaultServicePort := get $primaryService.ports (include "bjw-s.common.lib.service.primaryPort" (dict "values" $primaryService)) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 {{- if and (ne $routeKind "GRPCRoute") (ne $routeKind "HTTPRoute") (ne $routeKind "TCPRoute") (ne $routeKind "TLSRoute") (ne $routeKind "UDPRoute") }}
@@ -29,10 +29,10 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: {{ $routeKind }}
 metadata:
   name: {{ $fullName }}
-  {{- with (merge ($values.labels | default dict) (include "common.labels" $ | fromYaml)) }}
+  {{- with (merge ($values.labels | default dict) (include "bjw-s.common.lib.metadata.allLabels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with (merge ($values.annotations | default dict) (include "common.annotations" $ | fromYaml)) }}
+  {{- with (merge ($values.annotations | default dict) (include "bjw-s.common.lib.metadata.globalAnnotations" $ | fromYaml)) }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/library/common/templates/loader/_generate.tpl
+++ b/charts/library/common/templates/loader/_generate.tpl
@@ -31,4 +31,5 @@ Secondary entrypoint and primary loader for the common chart
   {{- include "bjw-s.common.render.services" . | nindent 0 -}}
   {{- include "bjw-s.common.render.ingresses" . | nindent 0 -}}
   {{- include "bjw-s.common.render.serviceMonitors" . | nindent 0 -}}
+  {{- include "bjw-s.common.render.routes" . | nindent 0 -}}
 {{- end -}}

--- a/charts/library/common/templates/render/_routes.tpl
+++ b/charts/library/common/templates/render/_routes.tpl
@@ -1,5 +1,5 @@
 {{/* Renders the Route objects required by the chart */}}
-{{- define "common.route" -}}
+{{- define "bjw-s.common.render.routes" -}}
   {{- /* Generate named routes as required */ -}}
   {{- range $name, $route := .Values.route }}
     {{- if $route.enabled -}}
@@ -11,7 +11,8 @@
       {{- end -}}
 
       {{- $_ := set $ "ObjectValues" (dict "route" $routeValues) -}}
-      {{- include "common.classes.route" $ | nindent 0 -}}
+      {{- include "bjw-s.common.class.route" $ | nindent 0 -}}
+      {{- $_ := unset $.ObjectValues "route" -}}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -400,6 +400,60 @@ ingress:
     #    hosts:
     #      - chart-example.local
 
+# -- Configure the gateway routes for the chart here.
+# Additional routes can be added by adding a dictionary key similar to the 'main' route.
+# [[ref]](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2)
+# @default -- See below
+route:
+  main:
+    # -- Enables or disables the route
+    enabled: false
+
+    # -- Set the route kind
+    # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+    kind: HTTPRoute
+
+    # -- Override the name suffix that is used for this route.
+    nameOverride:
+
+    # -- Provide additional annotations which may be required.
+    annotations: {}
+
+    # -- Provide additional labels which may be required.
+    labels: {}
+
+    ## -- Configure the resource the route attaches to.
+    parentRefs:
+    -  # Group of the referent resource.
+      group: gateway.networking.k8s.io
+      # Kind of the referent resource.
+      kind: Gateway
+      # Name of the referent resource
+      name:
+      # Namespace of the referent resource
+      namespace:
+      # Name of the section within the target resource.
+      sectionName: ""
+
+    # -- Host addresses
+    hostnames: []
+
+    # -- Configure rules for routing. Defaults to the primary service.
+    rules:
+      -  # -- Configure backends where matching requests should be sent.
+        backendRefs:
+        - group: ""
+          kind: Service
+          name:
+          namespace:
+          port:
+          weight: 1
+        ## Configure conditions used for matching incoming requests. Only for HTTPRoutes
+        matches:
+          - path:
+              type: PathPrefix
+              value: /
+
 # -- Configure persistence for the chart here.
 # Additional items can be added by adding a dictionary key similar to the 'config' key.
 # [[ref]](https://bjw-s.github.io/helm-charts/docs/common-library/common-library-storage)

--- a/charts/other/app-template/Chart.yaml
+++ b/charts/other/app-template/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A common powered chart template. This can be useful for small projects that don't have their own chart.
 name: app-template
-version: 1.0.1
+version: 1.1.0
 kubeVersion: ">=1.22.0-0"
 maintainers:
   - name: bjw-s
@@ -10,12 +10,12 @@ maintainers:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 1.0.1
+    version: 1.1.0
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: |
-        **BREAKING**: Updated library version to 1.0.1.
+        Updated library version to 1.1.0.
       links:
         - name: Common library chart definition
           url: https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/Chart.yaml

--- a/charts/other/app-template/tests/configmap/metadata_test.yaml
+++ b/charts/other/app-template/tests/configmap/metadata_test.yaml
@@ -21,7 +21,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -48,7 +48,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -83,5 +83,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/controller/metadata_daemonset_test.yaml
+++ b/charts/other/app-template/tests/controller/metadata_daemonset_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/controller/metadata_deployment_test.yaml
+++ b/charts/other/app-template/tests/controller/metadata_deployment_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/controller/metadata_statefulset_test.yaml
+++ b/charts/other/app-template/tests/controller/metadata_statefulset_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/ingress/metadata_test.yaml
+++ b/charts/other/app-template/tests/ingress/metadata_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/pvc/metadata_test.yaml
+++ b/charts/other/app-template/tests/pvc/metadata_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: retain enabled should pass
     set:
@@ -42,7 +42,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -68,7 +68,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -102,5 +102,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/route/metadata_test.yaml
+++ b/charts/other/app-template/tests/route/metadata_test.yaml
@@ -23,7 +23,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-0.3.0
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -52,7 +52,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-0.3.0
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -89,5 +89,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-0.3.0
+            helm.sh/chart: app-template-1.1.0
             test_label: test

--- a/charts/other/app-template/tests/route/metadata_test.yaml
+++ b/charts/other/app-template/tests/route/metadata_test.yaml
@@ -1,0 +1,93 @@
+suite: route metadata
+templates:
+  - common.yaml
+tests:
+  - it: default metadata should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: test
+            namespace: test
+    asserts:
+      - documentIndex: &routeDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *routeDocument
+        isNull:
+          path: metadata.annotations
+      - documentIndex: *routeDocument
+        equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: RELEASE-NAME
+            helm.sh/chart: app-template-0.3.0
+
+  - it: custom metadata should pass
+    set:
+      route.main:
+        enabled: true
+        annotations:
+          test_annotation: test
+        labels:
+          test_label: test
+        parentRefs:
+          - name: test
+            namespace: test
+    asserts:
+      - documentIndex: &routeDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *routeDocument
+        equal:
+          path: metadata.annotations
+          value:
+            test_annotation: test
+      - documentIndex: *routeDocument
+        equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: RELEASE-NAME
+            helm.sh/chart: app-template-0.3.0
+            test_label: test
+
+  - it: custom metadata with global metadata should pass
+    set:
+      global:
+        labels:
+          global_label: test
+        annotations:
+          global_annotation: test
+      route.main:
+        enabled: true
+        annotations:
+          test_annotation: test
+        labels:
+          test_label: test
+        parentRefs:
+          - name: test
+            namespace: test
+    asserts:
+      - documentIndex: &routeDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *routeDocument
+        equal:
+          path: metadata.annotations
+          value:
+            global_annotation: test
+            test_annotation: test
+      - documentIndex: *routeDocument
+        equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: RELEASE-NAME
+            global_label: test
+            helm.sh/chart: app-template-0.3.0
+            test_label: test

--- a/charts/other/app-template/tests/route/presence_test.yaml
+++ b/charts/other/app-template/tests/route/presence_test.yaml
@@ -1,0 +1,84 @@
+suite: route presence
+templates:
+  - common.yaml
+tests:
+  - it: default should pass
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        not: true
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 1
+        not: true
+        isKind:
+          of: HTTPRoute
+
+  - it: explicitly disabled should pass
+    set:
+      route.main.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        not: true
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 1
+        not: true
+        isKind:
+          of: HTTPRoute
+
+  - it: explicitly enabled should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: test
+            namespace: test
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentIndex: 0
+        not: true
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 1
+        not: true
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 2
+        isKind:
+          of: HTTPRoute
+
+  - it: multiple enabled should pass
+    set:
+      route:
+        main:
+          enabled: true
+          parentRefs:
+            - name: main
+              namespace: main
+        test:
+          enabled: true
+          parentRefs:
+            - name: test
+              namespace: test
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        not: true
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 1
+        not: true
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 3
+        isKind:
+          of: HTTPRoute

--- a/charts/other/app-template/tests/route/service_reference_test.yaml
+++ b/charts/other/app-template/tests/route/service_reference_test.yaml
@@ -1,0 +1,54 @@
+suite: ingress service reference
+templates:
+  - common.yaml
+tests:
+  - it: default should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: parentName
+            namespace: parentNamespace
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *HTTPRouteDocument
+        equal:
+          path: spec.rules[0].backendRefs[0]
+          value:
+            group: ""
+            kind: Service
+            name: RELEASE-NAME-main
+            namespace: NAMESPACE
+            port: null
+            weight: 1
+
+  - it: custom service reference should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: parentName
+            namespace: parentNamespace
+        rules:
+          - backendRefs:
+            - group: test
+              name: pathService
+              port: 1234
+              namespace: serviceNamespace
+              weight: 123
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *HTTPRouteDocument
+        equal:
+          path: spec.rules[0].backendRefs[0]
+          value:
+            group: test
+            kind: Service
+            name: pathService
+            namespace: serviceNamespace
+            port: 1234
+            weight: 123

--- a/charts/other/app-template/tests/route/values_test.yaml
+++ b/charts/other/app-template/tests/route/values_test.yaml
@@ -1,0 +1,183 @@
+suite: route values
+templates:
+  - common.yaml
+tests:
+  - it: setting gateway should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: parentName
+            namespace: parentNamespace
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *HTTPRouteDocument
+        equal:
+          path: spec.parentRefs[0].name
+          value: parentName
+      - documentIndex: *HTTPRouteDocument
+        equal:
+          path: spec.parentRefs[0].namespace
+          value: parentNamespace
+
+  - it: custom host and path should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: parentName
+            namespace: parentNamespace
+        hostnames:
+          - chart-test.local
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *HTTPRouteDocument
+        equal:
+          path: spec.hostnames[0]
+          value: chart-test.local
+
+  - it: path matches should only be used for HTTPRoutes
+    set:
+      route:
+        main:
+          enabled: true
+          kind: HTTPRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+              - name: test
+                namespace: test
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /test
+        grpc:
+          enabled: true
+          kind: GRPCRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+              - name: test
+                namespace: test
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /test
+        tcp:
+          enabled: true
+          kind: TCPRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+              - name: test
+                namespace: test
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /test
+        tls:
+          enabled: true
+          kind: TLSRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+              - name: test
+                namespace: test
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /test
+        udp:
+          enabled: true
+          kind: UDPRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+              - name: test
+                namespace: test
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /test
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: GRPCRoute
+      - documentIndex: &HTTPRouteDocument 2
+        isNull:
+          path: spec.rules[0].matches
+      - documentIndex: &HTTPRouteDocument 3
+        isKind:
+          of: HTTPRoute
+      - documentIndex: &HTTPRouteDocument 3
+        equal:
+          path: spec.rules[0].matches
+          value:
+            - path:
+                type: PathPrefix
+                value: /test
+      - documentIndex: &HTTPRouteDocument 4
+        isKind:
+          of: TCPRoute
+      - documentIndex: &HTTPRouteDocument 4
+        isNull:
+          path: spec.rules[0].matches
+      - documentIndex: &HTTPRouteDocument 5
+        isKind:
+          of: TLSRoute
+      - documentIndex: &HTTPRouteDocument 5
+        isNull:
+          path: spec.rules[0].matches
+      - documentIndex: &HTTPRouteDocument 6
+        isKind:
+          of: UDPRoute
+      - documentIndex: &HTTPRouteDocument 6
+        isNull:
+          path: spec.rules[0].matches
+
+  - it: hostnames shouldn't be used for TCPRoutes and UDPRoutes
+    set:
+      route:
+        main:
+          enabled: true
+          kind: TCPRoute
+          hostnames:
+            - chart-test.local
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+        udp:
+          enabled: true
+          kind: UDPRoute
+          hostnames:
+            - chart-test.local
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: TCPRoute
+      - documentIndex: &HTTPRouteDocument 2
+        isNull:
+          path: spec.hostnames
+      - documentIndex: &HTTPRouteDocument 3
+        isKind:
+          of: UDPRoute
+      - documentIndex: &HTTPRouteDocument 3
+        isNull:
+          path: spec.hostnames

--- a/charts/other/app-template/tests/service/metadata_test.yaml
+++ b/charts/other/app-template/tests/service/metadata_test.yaml
@@ -18,7 +18,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/service: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/service: RELEASE-NAME
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -80,5 +80,5 @@ tests:
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/service: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.0.1
+            helm.sh/chart: app-template-1.1.0
             test_label: test


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Adds support for [Gateway API Routes](https://gateway-api.sigs.k8s.io/) similar to ingresses currently.

**Benefits**

With this update people using Gateway API for networking are able to add routes for their services using this chart instead of having to add only the route for the service created by chart.

The idea was to handle this behavior similar to how Ingresses are handled currently by the chart.

**Possible drawbacks**

Non really that I can think of, one caveat is that the Gateway API uses CRDs, so the user would need to install those first before using them with this chart.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
