### PR TITLE
fix(common): Fix NOTES always showing ingress protocol as http

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -17,3 +17,5 @@ annotations:
       description: Support services have extraSelectorLabels
     - kind: changed
       description: Updated code-server image to v4.8.1
+    - kind: fixed
+      description: Fix NOTES always showing ingress protocol as http

--- a/charts/library/common/templates/_notes.tpl
+++ b/charts/library/common/templates/_notes.tpl
@@ -22,7 +22,7 @@ Default NOTES.txt content.
 {{- if $primaryIngress }}
 1. Access the application by visiting one of these URL's:
 {{ range $primaryIngress.hosts }}
-  {{- $protocol := "http" -}}
+  {{- $prefix = "http" -}}
   {{ if $primaryIngress.tls -}}
     {{- $prefix = "https" -}}
   {{ end -}}
@@ -34,7 +34,7 @@ Default NOTES.txt content.
   {{ if (first .paths).pathTpl -}}
     {{- $path = tpl (first .paths).pathTpl $ -}}
   {{ end }}
-  - {{ $protocol }}://{{- $host }}{{- $path }}
+  - {{ $prefix }}://{{- $host }}{{- $path }}
 {{- end }}
 {{- else if and $primaryService $primaryPort }}
 1. Get the application URL by running these commands:


### PR DESCRIPTION
**Description of the change**

NOTES generation inconsistently uses `$protocol` and `$prefix` to add the protocol to the output URL. This causes ingresses to always show as `http://...`. This PR removes the `$protocol` var and uses `$prefix` to match the behavior of NOTES when ingress is disabled.

**Benefits**

NOTES will give a more accurate deployment URL.

**Possible drawbacks**

Slight change to NOTES output, which is currently always `http`.

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
