### PR TITLE
fix(common): `httpGet` probes template failed to render

### DIFF
--- a/.ci/mkdocs/requirements.txt
+++ b/.ci/mkdocs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.4.2
 mkdocs-macros-plugin ==0.7.0
-mkdocs-material ==8.5.7
+mkdocs-material ==8.5.9
 mkdocs-minify-plugin==0.6.1
 mkdocs-redirects==1.2.0

--- a/charts/library/common/templates/lib/container/_probes.tpl
+++ b/charts/library/common/templates/lib/container/_probes.tpl
@@ -22,7 +22,7 @@ Probes selection logic.
         {{- else -}}
           {{- $probeType = $probe.type | default "TCP" -}}
         {{- end }}
-        {{- if or ( eq $probeType "HTTPS" ) ( eq $probeType "HTTP" ) -}}
+        {{- if or ( eq $probeType "HTTPS" ) ( eq $probeType "HTTP" ) }}
   httpGet:
     path: {{ $probe.path }}
     scheme: {{ $probeType }}


### PR DESCRIPTION
`httpGet` was not rendered because we removed too many spaces.
