### PR TITLE
fix(common) - fix incorrect route default values

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.1.3
+version: 1.1.4
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -15,24 +15,6 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: fixed
-      description: Fixed code-server add-on Service rendering
+      description: Fixed sectionName not being optional for gateway routes
     - kind: fixed
-      description: Fixed httpGet probe whitespace rendering
-    - kind: fixed
-      description: Fixed serviceAccount definition to be compatible with k8s 1.25
-      links:
-        - name: Secret management for ServiceAccounts
-          url: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#manual-secret-management-for-serviceaccounts
-    - kind: added
-      description: Added support for Gateway API Routes
-      links:
-        - name: Gateway API docs
-          url: https://gateway-api.sigs.k8s.io
-    - kind: changed
-      description: Services and their ports are now assumed enabled by default
-    - kind: changed
-      description: Updated netshoot image to v0.8
-    - kind: changed
-      description: Updated code-server image to v4.8.3
-    - kind: removed
-      description: Removed promtail add-on
+      description: Fixed primary gateway route having incorrect name

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -42,7 +42,9 @@ spec:
       kind: {{ default "Gateway" .kind }}
       name: {{ required (printf "parentRef name is required for %v %v" $routeKind $fullName) .name }}
       namespace: {{ required (printf "parentRef namespace is required for %v %v" $routeKind $fullName) .namespace }}
-      sectionName: {{ default "" .sectionName | quote}}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName | quote }}
+      {{- end }}
   {{- end }}
   {{- if and (ne $routeKind "TCPRoute") (ne $routeKind "UDPRoute") $values.hostnames }}
   hostnames:

--- a/charts/library/common/templates/lib/routes/_primary.tpl
+++ b/charts/library/common/templates/lib/routes/_primary.tpl
@@ -1,0 +1,21 @@
+{{/* Return the name of the primary route object */}}
+{{- define "bjw-s.common.lib.route.primary" -}}
+  {{- $enabledRoutes := dict -}}
+  {{- range $name, $route := .Values.route -}}
+    {{- if $route.enabled -}}
+      {{- $_ := set $enabledRoutes $name . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $result := "" -}}
+  {{- range $name, $route := $enabledRoutes -}}
+    {{- if and (hasKey $route "primary") $route.primary -}}
+      {{- $result = $name -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if not $result -}}
+    {{- $result = keys $enabledRoutes | first -}}
+  {{- end -}}
+  {{- $result -}}
+{{- end -}}

--- a/charts/library/common/templates/render/_routes.tpl
+++ b/charts/library/common/templates/render/_routes.tpl
@@ -6,7 +6,7 @@
       {{- $routeValues := $route -}}
 
       {{/* set defaults */}}
-      {{- if not $routeValues.nameOverride -}}
+      {{- if and (not $routeValues.nameOverride) (ne $name (include "bjw-s.common.lib.route.primary" $)) -}}
         {{- $_ := set $routeValues "nameOverride" $name -}}
       {{- end -}}
 

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -422,7 +422,7 @@ route:
     # -- Provide additional labels which may be required.
     labels: {}
 
-    ## -- Configure the resource the route attaches to.
+    # -- Configure the resource the route attaches to.
     parentRefs:
     -  # Group of the referent resource.
       group: gateway.networking.k8s.io
@@ -433,7 +433,7 @@ route:
       # Namespace of the referent resource
       namespace:
       # Name of the section within the target resource.
-      sectionName: ""
+      sectionName:
 
     # -- Host addresses
     hostnames: []

--- a/charts/other/app-template/Chart.yaml
+++ b/charts/other/app-template/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A common powered chart template. This can be useful for small projects that don't have their own chart.
 name: app-template
-version: 1.1.3
+version: 1.1.4
 kubeVersion: ">=1.22.0-0"
 maintainers:
   - name: bjw-s
@@ -10,12 +10,12 @@ maintainers:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 1.1.3
+    version: 1.1.4
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: |
-        Updated library version to 1.1.3.
+        Updated library version to 1.1.4.
       links:
         - name: Common library chart definition
           url: https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/Chart.yaml

--- a/charts/other/app-template/tests/configmap/metadata_test.yaml
+++ b/charts/other/app-template/tests/configmap/metadata_test.yaml
@@ -23,7 +23,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -52,7 +52,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -89,5 +89,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/controller/metadata_daemonset_test.yaml
+++ b/charts/other/app-template/tests/controller/metadata_daemonset_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/controller/metadata_deployment_test.yaml
+++ b/charts/other/app-template/tests/controller/metadata_deployment_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/controller/metadata_statefulset_test.yaml
+++ b/charts/other/app-template/tests/controller/metadata_statefulset_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/ingress/metadata_test.yaml
+++ b/charts/other/app-template/tests/ingress/metadata_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -79,5 +79,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/pvc/metadata_test.yaml
+++ b/charts/other/app-template/tests/pvc/metadata_test.yaml
@@ -19,7 +19,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: retain enabled should pass
     set:
@@ -42,7 +42,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -68,7 +68,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -102,5 +102,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/route/metadata_test.yaml
+++ b/charts/other/app-template/tests/route/metadata_test.yaml
@@ -23,7 +23,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -52,7 +52,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -89,5 +89,5 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test

--- a/charts/other/app-template/tests/route/service_reference_test.yaml
+++ b/charts/other/app-template/tests/route/service_reference_test.yaml
@@ -19,7 +19,7 @@ tests:
           value:
             group: ""
             kind: Service
-            name: RELEASE-NAME-main
+            name: RELEASE-NAME
             namespace: NAMESPACE
             port: null
             weight: 1

--- a/charts/other/app-template/tests/route/values_test.yaml
+++ b/charts/other/app-template/tests/route/values_test.yaml
@@ -181,3 +181,32 @@ tests:
       - documentIndex: &HTTPRouteDocument 3
         isNull:
           path: spec.hostnames
+
+  - it: sectionName in parentRefs should be optional
+    set:
+      route:
+        main:
+          enabled: true
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+        second:
+          enabled: true
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+              sectionName: parentSection
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: &HTTPRouteDocument 2
+        isNull:
+          path: spec.parentRefs[0].sectionName
+      - documentIndex: &HTTPRouteDocument 3
+        isKind:
+          of: HTTPRoute
+      - documentIndex: &HTTPRouteDocument 3
+        equal:
+          path: spec.parentRefs[0].sectionName
+          value: parentSection

--- a/charts/other/app-template/tests/secret/metadata_test.yaml
+++ b/charts/other/app-template/tests/secret/metadata_test.yaml
@@ -23,7 +23,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -52,7 +52,7 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -89,7 +89,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom secret type should pass

--- a/charts/other/app-template/tests/service/metadata_test.yaml
+++ b/charts/other/app-template/tests/service/metadata_test.yaml
@@ -18,7 +18,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/service: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
 
   - it: custom metadata should pass
     set:
@@ -45,7 +45,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/service: RELEASE-NAME
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test
 
   - it: custom metadata with global metadata should pass
@@ -80,5 +80,5 @@ tests:
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/service: RELEASE-NAME
             global_label: test
-            helm.sh/chart: app-template-1.1.3
+            helm.sh/chart: app-template-1.1.4
             test_label: test


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->
Fixed couple of issues regarding gateway routes, details below.

#### Fixed
<!-- Any functionality that has been fixed -->
The primary route was named incorrectly and this resulted in it referencing the primary service incorrectly, creating a broken route.
The `sectionName` was picking up empty string as a default value if not provided instead of being skipped, this made the route invalid if this value wasn't provided.

### Benefits
<!-- What benefits will be realized by the code change? -->
Routes can be used with the above values left to default, currently one has to provide these to have correct behaviour.

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
