### PR TITLE
fix(common): Increase CronJob pod annotations indent from 10 to 12

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.3.1
+version: 1.3.2
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -15,4 +15,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: fixed
-      description: Probes were rendered incorrectly when primary service port was a string.
+      description: Pod annotations were not indented enough when controller type was cronjob

--- a/charts/library/common/README.md
+++ b/charts/library/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for Helm charts
 

--- a/charts/library/common/templates/classes/_cronjob.tpl
+++ b/charts/library/common/templates/classes/_cronjob.tpl
@@ -34,7 +34,7 @@ spec:
         metadata:
           {{- with include ("bjw-s.common.lib.metadata.podAnnotations") . }}
           annotations:
-            {{- . | nindent 10 }}
+            {{- . | nindent 12 }}
           {{- end }}
           labels:
             {{- include "bjw-s.common.lib.metadata.selectorLabels" . | nindent 12 }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->

This PR fixes an incorrect indent for pod annotations when `controller.type` is `CronJob`. 

#99 increased this indent from 8 to 10, but this is still incorrect. Pod annotations need to be indented by 12 spaces.

#### Removed
<!-- Any features that have been removed -->

#### Fixed
<!-- Any functionality that has been fixed -->

#### Added
<!-- Any new features that have been added -->

#### Changed
<!-- Any features that have been changed from how they were working before -->

- CronJob pod annotations indent increased from 10 to 12

### Benefits
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
<!-- Describe any known limitations with your change -->

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

Example:
```yaml
spec:
  ...
  jobTemplate:
    spec:
      template:
        metadata:
          annotations:
          checksum/config: 48e0fde9b8afe61e94fd56fbe74506b67f029101228afa451372412dcbd8d105
          labels:
            app.kubernetes.io/name: borgmatic
            app.kubernetes.io/instance: borgmatic
```

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
