### PR TITLE
fix(common): quote command and args strings

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.3.2
+version: 1.3.3
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -14,6 +14,8 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
+    - kind: changed
+      description: Quoting args string to support multiline arguments
     - kind: changed
       description: Updated code-server image tag to v4.10.0
     - kind: changed

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Quoting args string to support multiline arguments
+      description: Quoting command and args strings to support multiline arguments
     - kind: changed
       description: Updated code-server image tag to v4.10.0
     - kind: changed

--- a/charts/library/common/templates/lib/controller/_mainContainer.tpl
+++ b/charts/library/common/templates/lib/controller/_mainContainer.tpl
@@ -6,7 +6,7 @@
   {{- with .Values.command }}
   command:
     {{- if kindIs "string" . }}
-    - {{ . }}
+    - {{ quote . }}
     {{- else }}
       {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/library/common/templates/lib/controller/_mainContainer.tpl
+++ b/charts/library/common/templates/lib/controller/_mainContainer.tpl
@@ -14,7 +14,7 @@
   {{- with .Values.args }}
   args:
     {{- if kindIs "string" . }}
-    - {{ . }}
+    - {{ quote . }}
     {{- else }}
     {{ toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
### Description of the change

Quote the command and args strings to support multiline arguments.

#### Changed

Quote the `command` and `args` strings in the main container.

### Benefits

Without the quoting of the `command` and `args` strings, the following gives an error:

```yaml
command:
  - "/bin/sh"
  - "-c"
args: |
  echo hello
  echo world
```

The error (which is quite vague):

> Error: YAML parse error on cronjob/templates/render.yaml: error converting YAML to JSON: yaml: line 48: could not find expected ':'

`args: >` does work without this change, but that requires you to add semicolons to each line.

### Possible drawbacks

If someone manually quoted the `command` or `args` string, it will now be double quoted.

## Checklist

- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
