### PR TITLE
[common] Reload pod on secret change

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.3.2
+version: 1.4.0
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -14,9 +14,5 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Updated code-server image tag to v4.10.0
-    - kind: changed
-      description: Updated netshoot image tag to v0.9
-    - kind: fixed
-      description: Pod annotations were not indented enough when controller type was cronjob
+    - kind: added
+      description: reload pod when secrets change

--- a/charts/library/common/templates/lib/metadata/_podAnnotations.tpl
+++ b/charts/library/common/templates/lib/metadata/_podAnnotations.tpl
@@ -13,4 +13,14 @@
   {{- if $configMapsFound -}}
     {{- printf "checksum/config: %v" (toYaml $configMapsFound | sha256sum) | nindent 0 -}}
   {{- end -}}
+
+  {{- $secretsFound := dict -}}
+  {{- range $name, $secret := .Values.secrets -}}
+    {{- if $secret.enabled -}}
+      {{- $_ := set $secretsFound $name (toYaml $secret.data | sha256sum) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $secretsFound -}}
+    {{- printf "checksum/secrets: %v" (toYaml $secretsFound | sha256sum) | nindent 0 -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/other/app-template/tests/secret/pod_metadata_test.yaml
+++ b/charts/other/app-template/tests/secret/pod_metadata_test.yaml
@@ -1,0 +1,25 @@
+suite: secret Pod metadata
+templates:
+  - common.yaml
+tests:
+  - it: default metadata should pass
+    set:
+      secrets:
+        secret_1:
+          enabled: true
+          data:
+            test: value 1
+        secret_2:
+          enabled: true
+          data:
+            test_1: value 1
+            test_2: value 2
+    asserts:
+      - documentIndex: &ControllerDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *ControllerDoc
+        equal:
+          path: spec.template.metadata.annotations
+          value:
+            checksum/secrets: cd4e5076088172611ca1c43c659a275232d9eeb887acc20575ac141038b9aacb


### PR DESCRIPTION
### Description of the change
Reload pod on secrets change

#### Removed
None

#### Fixed
None

#### Added
When a secret is added/modified/deleted the pod is reloaded.

#### Changed
None

### Benefits
Pod always using latest secrets

### Possible drawbacks
Unneeded reloads when pod can use the new secret without reload

### Applicable issues
NA

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
