### PR TITLE
feat(common): omit replicas field in Deployment if null is given

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.4.0
+version: 1.5.0
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -14,6 +14,8 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
+    - kind: changed
+      description: Omit replicas field in Deployment if null is given
     - kind: added
       description: Reload Pod when secrets change
     - kind: changed

--- a/charts/library/common/templates/classes/_deployment.tpl
+++ b/charts/library/common/templates/classes/_deployment.tpl
@@ -20,7 +20,9 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
+  {{- if not (eq .Values.controller.replicas nil) }}
   replicas: {{ .Values.controller.replicas }}
+  {{- end }}
   strategy:
     type: {{ $strategy }}
     {{- with .Values.controller.rollingUpdate }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -19,7 +19,7 @@ controller:
   annotations: {}
   # -- Set labels on the deployment/statefulset/daemonset/cronjob
   labels: {}
-  # -- Number of desired pods
+  # -- Number of desired pods. When using a HorizontalPodAutoscaler, set this to `null`.
   replicas: 1
   # -- Set the controller upgrade strategy
   # For Deployments, valid values are Recreate (default) and RollingUpdate.


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->

When using a HorizontalPodAutoscaler, the "replicas" field must be omitted. As per the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas).

> If a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (or any similar API for horizontal scaling) is managing scaling for a Deployment, don't set .spec.replicas.

This ensures the Deployment will not scale down when doing a (rolling) update of the Pods.

#### Changed
<!-- Any features that have been changed from how they were working before -->

Omit `replicas` field in Deployment if `controller.replicas = null`.

### Benefits
<!-- What benefits will be realized by the code change? -->

This allows the use of a HorizontalPodAutoscaler in combination with the Deployment that this chart creates.

### Possible drawbacks
<!-- Describe any known limitations with your change -->

When specifying `replicas: null` or `replicas:` in the Kubernetes manifest, the default number of 1 Pod will be used. In case anyone is using this, the amount of replicas stays the same, but will no longer be updated by the Kubernetes manifest on subsequent applies.

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

N/A

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

None

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
