### PR TITLE
fix(common): evaluate ingress secret name before condition

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 1.5.0
+version: 1.5.1
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -14,15 +14,5 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
-    - kind: added
-      description: support for for hostPID
-    - kind: added
-      description: support for for hostPID
-    - kind: added
-      description: Add support for CronJob backoffLimit
-    - kind: changed
-      description: Omit replicas field in Deployment if null is given
-    - kind: changed
-      description: Updated code-server image tag to v4.12.0
-    - kind: changed
-      description: Updated netshoot image tag to v0.10
+    - kind: fixed
+      description: Ingress secret name template is evaluated before deciding whether to omit it

--- a/charts/library/common/templates/classes/_ingress.tpl
+++ b/charts/library/common/templates/classes/_ingress.tpl
@@ -41,12 +41,13 @@ spec:
   {{- if $values.tls }}
   tls:
     {{- range $values.tls }}
+    {{- $secretName := tpl .secretName $ }}
     - hosts:
         {{- range .hosts }}
         - {{ tpl . $ | quote }}
         {{- end }}
-      {{- if .secretName }}
-      secretName: {{ tpl .secretName $ | quote}}
+      {{- if $secretName }}
+      secretName: {{ $secretName | quote}}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/library/common/templates/classes/_ingress.tpl
+++ b/charts/library/common/templates/classes/_ingress.tpl
@@ -41,11 +41,11 @@ spec:
   {{- if $values.tls }}
   tls:
     {{- range $values.tls }}
-    {{- $secretName := tpl .secretName $ }}
     - hosts:
         {{- range .hosts }}
         - {{ tpl . $ | quote }}
         {{- end }}
+      {{- $secretName := tpl (default "" .secretName) $ }}
       {{- if $secretName }}
       secretName: {{ $secretName | quote}}
       {{- end }}

--- a/charts/other/app-template/Chart.yaml
+++ b/charts/other/app-template/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A common powered chart template. This can be useful for small projects that don't have their own chart.
 name: app-template
-version: 1.5.0
+version: 1.5.1
 kubeVersion: ">=1.22.0-0"
 maintainers:
   - name: bjw-s
@@ -10,12 +10,12 @@ maintainers:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 1.5.0
+    version: 1.5.1
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: |
-        Updated library version to 1.5.0.
+        Updated library version to 1.5.1.
       links:
         - name: Common library chart definition
           url: https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/Chart.yaml

--- a/charts/other/app-template/tests/ingress/tls_test.yaml
+++ b/charts/other/app-template/tests/ingress/tls_test.yaml
@@ -70,3 +70,22 @@ tests:
             secretName: RELEASE-NAME-secret
             hosts:
               - hostname
+
+  - it: tls enabled with secret template evaluate empty should pass
+    set:
+      ingress.main:
+        enabled: true
+        tls:
+          - secretName: '{{ "" }}'
+            hosts:
+              - hostname
+    asserts:
+      - documentIndex: &IngressDocument 2
+        isKind:
+          of: Ingress
+      - documentIndex: *IngressDocument
+        equal:
+          path: spec.tls[0]
+          value:
+            hosts:
+              - hostname


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
Evaluates the ingress TLS secret name as a template before deciding whether to include or or omit the `secretName` field.

#### Fixed
Using an ingress TLS secret name template evaluating to an empty string resulted in the `secretName` field still being added to the ingress TLS config with an empty string value.

### Benefits
Allows using a template that may or may not cause the `secretName` field to be present in the Ingress TLS config.

### Possible drawbacks
I guess this takes away the ability to ever add the ingress TLS secret name as an empty string. But I'm not sure ever having that as empty string is a valid use case.

### Applicable issues
None

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] ~Variables have been documented in the `values.yaml` file.~
