### PR TITLE
fix(common): fix for wrong default main ingress value

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 2.0.3
+version: 2.0.4
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -16,4 +16,4 @@ annotations:
   artifacthub.io/changes: |-
     - kind: fixed
       description: |-
-        Volumes did not render correctly across multiple controllers
+        Changed value for main ingress to true

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -479,7 +479,7 @@ serviceMonitor:
 ingress:
   main:
     # -- Enables or disables the ingress
-    enabled: false
+    enabled: true
 
     # -- Make this the primary ingress (used in probes, notes, etc...).
     # If there is more than 1 ingress, make sure that only 1 ingress is marked as primary.


### PR DESCRIPTION
### Description of the change
Default main ingress value is wrong and according to docs should be true.

#### Fixed
changed default from `false` to `true`.
Fixes #208

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
