### PR TITLE
bugfix(gateway-apis): Specific filters without BackendRefs

### DIFF
--- a/charts/library/common-test/tests/route/service_reference_test.yaml
+++ b/charts/library/common-test/tests/route/service_reference_test.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
-suite: ingress service reference
+suite: route service reference
 templates:
   - common.yaml
 tests:
@@ -54,3 +54,52 @@ tests:
             namespace: serviceNamespace
             port: 1234
             weight: 123
+
+  - it: custom service reference with filter should fail
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: parentName
+            namespace: parentNamespace
+        rules:
+          - backendRefs:
+              - group: test
+                name: pathService
+                port: 1234
+                namespace: serviceNamespace
+                weight: 123
+            filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  scheme: https
+                  statusCode: 301
+    asserts:
+      - failedTemplate:
+          errorMessage: "backend refs and request redirect filters cannot co-exist."
+
+  - it: custom service with filter should pass
+    set:
+      route.main:
+        enabled: true
+        parentRefs:
+          - name: parentName
+            namespace: parentNamespace
+        rules:
+          - filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  scheme: https
+                  statusCode: 301
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: HTTPRoute
+      - documentIndex: *HTTPRouteDocument
+        equal:
+          path: spec.rules[0].filters[0]
+          value:
+            type: RequestRedirect
+            requestRedirect:
+              scheme: https
+              statusCode: 301

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -17,3 +17,6 @@ annotations:
     - kind: fixed
       description: |-
         Defaulting image tags to chart.Appversion was removed without a proper alternative
+    - kind: fixed
+      description: |-
+        Using RequestRedirect is not allowed with BackendRefs in Routes.

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 2.3.0
+version: 2.3.1
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -14,21 +14,6 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
-    - kind: added
-      description: |-
-        Add support for `appProtocol` in Kubernetes services.
-    - kind: added
-      description: |-
-        Add support for route filters for HTTPRoute and GRPCRoute.
-    - kind: added
-      description: |-
-        Add support `dataSource` and `dataSourceRef` fields in StatefulSet volumeClaimTemplates.
-    - kind: added
-      description: |-
-        Add support `dataSource` and `dataSourceRef` fields in persistentVolumeClaim persistence items.
-    - kind: fixed
-      description: |-
-        GRPCRoute support for matches was not supported.
     - kind: fixed
       description: |-
         `valuefrom`-style environment variables can now use Helm templating again.

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -24,9 +24,6 @@ within the common library.
   -}}
 ---
 apiVersion: {{ $apiVersion }}
-{{- if and (ne $routeKind "GRPCRoute") (ne $routeKind "HTTPRoute") (ne $routeKind "TCPRoute") (ne $routeKind "TLSRoute") (ne $routeKind "UDPRoute") }}
-  {{- fail (printf "Not a valid route kind (%s)" $routeKind) }}
-{{- end }}
 kind: {{ $routeKind }}
 metadata:
   name: {{ $routeObject.name }}

--- a/charts/library/common/templates/lib/routes/_validate.tpl
+++ b/charts/library/common/templates/lib/routes/_validate.tpl
@@ -3,5 +3,23 @@ Validate Route values
 */}}
 {{- define "bjw-s.common.lib.route.validate" -}}
   {{- $rootContext := .rootContext -}}
-  {{- $routeValues := .object -}}
+  {{- $routeObject := .object -}}
+
+  {{/* Route Types */}}
+  {{- $routeKind := $routeObject.kind | default "HTTPRoute"}}
+  {{- if and (ne $routeKind "GRPCRoute") (ne $routeKind "HTTPRoute") (ne $routeKind "TCPRoute") (ne $routeKind "TLSRoute") (ne $routeKind "UDPRoute") }}
+    {{- fail (printf "Not a valid route kind (%s)" $routeKind) }}
+  {{- end }}
+
+  {{/* Route Rules */}}
+
+  {{- range $routeObject.rules }}
+  {{- if and (.backendRefs) (.filters) }}
+    {{- range .filters }}
+      {{- if eq .type "RequestRedirect" }}
+        {{- fail (printf "backend refs and request redirect filters cannot co-exist.")}}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end -}}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->
Moves some parts to validation ensuring that a route will not be created with incorrect parameters.
This also allows us to set a filter without a backend ref in case it goes directly to the Gateway for reprocessing

#### Fixed
<!-- Any functionality that has been fixed -->
Using `RequestRedirect` is not allowed with `BackendRefs`. 
I added a check to validate this and fail if it's present.

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
