### PR TITLE
feat(gateway-api): add timeouts for httproute as per spec

### DIFF
--- a/charts/library/common-test/tests/route/values_test.yaml
+++ b/charts/library/common-test/tests/route/values_test.yaml
@@ -83,6 +83,8 @@ tests:
                     path:
                       type: ReplacePrefixMatch
                       replacePrefixMatch: ""
+              timeouts:
+                backendRequest: 30s
         grpc:
           enabled: true
           kind: GRPCRoute
@@ -229,6 +231,9 @@ tests:
       - documentIndex: &HTTPRouteDocument 6
         notExists:
           path: spec.rules[0].filters
+      - documentIndex: &HTTPRouteDocument 6
+        notExists:
+          path: spec.rules[0].timeouts
 
   - it: hostnames shouldn't be used for TCPRoutes and UDPRoutes
     set:
@@ -291,3 +296,49 @@ tests:
         equal:
           path: spec.parentRefs[0].sectionName
           value: parentSection
+
+  - it: timeouts should only be used for HTTPRoutes
+    set:
+      route:
+        main:
+          enabled: true
+          kind: HTTPRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+                - name: test
+                  namespace: test
+              timeouts:
+                backendRequest: 30s
+        grpc:
+          enabled: true
+          kind: GRPCRoute
+          parentRefs:
+            - name: parentName
+              namespace: parentNamespace
+          rules:
+            - backendRefs:
+                - name: test
+                  namespace: test
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /test
+              timeouts:
+                backendRequest: 10s
+    asserts:
+      - documentIndex: &HTTPRouteDocument 2
+        isKind:
+          of: GRPCRoute
+      - documentIndex: &HTTPRouteDocument 2
+        notExists:
+          path: spec.rules[0].timeouts.backendRequest
+      - documentIndex: &HTTPRouteDocument 3
+        isKind:
+          of: HTTPRoute
+      - documentIndex: &HTTPRouteDocument 3
+        equal:
+          path: spec.rules[0].timeouts.backendRequest
+          value: 30s

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 2.3.0
+version: 2.4.1
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -16,19 +16,4 @@ annotations:
   artifacthub.io/changes: |-
     - kind: added
       description: |-
-        Add support for `appProtocol` in Kubernetes services.
-    - kind: added
-      description: |-
-        Add support for route filters for HTTPRoute and GRPCRoute.
-    - kind: added
-      description: |-
-        Add support `dataSource` and `dataSourceRef` fields in StatefulSet volumeClaimTemplates.
-    - kind: added
-      description: |-
-        Add support `dataSource` and `dataSourceRef` fields in persistentVolumeClaim persistence items.
-    - kind: fixed
-      description: |-
-        GRPCRoute support for matches was not supported.
-    - kind: fixed
-      description: |-
-        `valuefrom`-style environment variables can now use Helm templating again.
+        Add support for `timeouts` in HTTPRoute.

--- a/charts/library/common/README.md
+++ b/charts/library/common/README.md
@@ -175,7 +175,7 @@ The following table contains an overview of available values and their descripti
 | route.main.labels | object | `{}` | Provide additional labels which may be required. |
 | route.main.nameOverride | string | `nil` | Override the name suffix that is used for this route. |
 | route.main.parentRefs | list | `[{"group":"gateway.networking.k8s.io","kind":"Gateway","name":null,"namespace":null,"sectionName":null}]` | Configure the resource the route attaches to. |
-| route.main.rules | list | `[{"backendRefs":[{"group":"","kind":"Service","name":"main","namespace":null,"port":null,"weight":1}],"filters":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Configure rules for routing. Defaults to the primary service. |
+| route.main.rules | list | `[{"backendRefs":[{"group":"","kind":"Service","name":"main","namespace":null,"port":null,"weight":1}],"timeouts":{}"filters":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Configure rules for routing. Defaults to the primary service. |
 | route.main.rules[0].backendRefs | list | `[{"group":"","kind":"Service","name":"main","namespace":null,"port":null,"weight":1}]` | Configure backends where matching requests should be sent. |
 | secrets | object | See below | Use this to populate secrets with the values you specify. Be aware that these values are not encrypted by default, and could therefore visible to anybody with access to the values.yaml file. Additional Secrets can be added by adding a dictionary key similar to the 'secret' object. |
 | secrets.secret.annotations | object | `{}` | Annotations to add to the Secret |

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -79,5 +79,11 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
     {{- end }}
+    {{- if (eq $routeKind "HTTPRoute") }}
+      {{- with .timeouts }}
+    timeouts:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -603,6 +603,8 @@ route:
               value: /
         ## Request filters that are applied to the rules.
         filters: []
+        ## Request timeout that are applied to the rules.
+        timeouts: {}
 
 # -- Configure persistence for the chart here.
 # Additional items can be added by adding a dictionary key similar to the 'config' key.


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->

Adds support for timeouts field in HTTPRoute

#### Added
<!-- Any new features that have been added -->
Support increasing the timeout before client timeout 499 or backendRequest timeout. See spec below.
[Route Timeout Spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteTimeouts)

### Benefits
<!-- What benefits will be realized by the code change? -->

When needing a fixed or more amount of time for backends to complete their requests this field allows people using route to send a long timeout so the request can complete without it being killed/chunked by the Gateway-API implementation

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
