### PR TITLE
feat(common): add suspend option to CronJob controller

### DIFF
--- a/charts/library/common-test/tests/controller/cronjob_test.yaml
+++ b/charts/library/common-test/tests/controller/cronjob_test.yaml
@@ -14,6 +14,9 @@ tests:
         isKind:
           of: CronJob
       - documentIndex: *ControllerDoc
+        notExists:
+          path: spec.suspend
+      - documentIndex: *ControllerDoc
         equal:
           path: spec.schedule
           value: "*/20 * * * *"
@@ -45,6 +48,7 @@ tests:
           pod:
             restartPolicy: OnFailure
           cronjob:
+            suspend: &CronJobSuspended true
             schedule: &CronJobSchedule "0 3 * * *"
             concurrencyPolicy: &CronJobConcurrencyPolicy "Test"
             failedJobsHistory: &CronJobFailedJobsHistory 2
@@ -54,6 +58,10 @@ tests:
       - documentIndex: &ControllerDoc 0
         isKind:
           of: CronJob
+      - documentIndex: *ControllerDoc
+        equal:
+          path: spec.suspend
+          value: *CronJobSuspended
       - documentIndex: *ControllerDoc
         equal:
           path: spec.schedule

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 2.4.0
+version: 2.5.0
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -16,30 +16,4 @@ annotations:
   artifacthub.io/changes: |-
     - kind: added
       description: |-
-        Add support for `timeouts` in HTTPRoute.
-    - kind: added
-      description: |-
-        Add support for `workingDir` for containers.
-    - kind: fixed
-      description: |-
-        Defaulting image tags to chart.Appversion was removed without a proper alternative
-    - kind: fixed
-      description: |-
-        Using RequestRedirect is not allowed with BackendRefs in Routes.
-    - kind: fixed
-      description: |-
-        StatefulSet objects would not always fall back to proper defaults and error out
-    - kind: changed
-      description: |-
-        routes will no longer auto target its service.
-        It will need to be explicitly defined as below
-
-        ```yaml
-        - backendRefs:
-            - group: ""
-              kind: Service
-              name: foo
-              namespace: foo-namespace
-              port: 8080
-              weight: 1
-        ```
+        Support suspending CronJob

--- a/charts/library/common/templates/classes/_cronjob.tpl
+++ b/charts/library/common/templates/classes/_cronjob.tpl
@@ -32,6 +32,9 @@ metadata:
   annotations: {{- toYaml . | nindent 4 -}}
   {{- end }}
 spec:
+  {{- with $cronjobObject.cronjob.suspend }}
+  suspend: {{ ternary "true" "false" . }}
+  {{- end }}
   concurrencyPolicy: "{{ $cronjobObject.cronjob.concurrencyPolicy }}"
   startingDeadlineSeconds: {{ $cronjobObject.cronjob.startingDeadlineSeconds }}
   {{- with $timeZone }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -132,6 +132,10 @@ controllers:
     # -- CronJob configuration. Required only when using `controller.type: cronjob`.
     # @default -- See below
     cronjob:
+      # -- Suspends the CronJob
+      # [[ref]](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-suspension)
+      # @default -- false
+      suspend:
       # -- Specifies how to treat concurrent executions of a job that is created by this cron job
       # valid values are Allow, Forbid or Replace
       concurrencyPolicy: Forbid
@@ -145,7 +149,7 @@ controllers:
       successfulJobsHistory: 1
       # -- The number of failed Jobs to keep
       failedJobsHistory: 1
-      # --  If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to
+      # -- If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to
       # be automatically deleted.
       ttlSecondsAfterFinished:
       # -- Limits the number of times a failed job will be retried


### PR DESCRIPTION
### Description of the change

It is currently not possible to suspend the CronJob, even though Kubernetes supports this natively. This PR adds support for this option.

The suspend option defaults to `false` when omitted, so always setting `spec.suspend` could result in a dirty diffs even though functionally nothing changes. Therefore I've opted to only add it when explicitly set.

#### Added

Adds the ability to suspend the CronJob as described here: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-suspension.

### Benefits

More feature complete common chart.

### Possible drawbacks

> When .spec.suspend changes from true to false on an existing CronJob without a starting deadline, the missed jobs are scheduled immediately.

The documentation recommends setting a starting deadline. The common chart already sets this by default: [`startingDeadlineSeconds: 30`](https://github.com/bjw-s/helm-charts/blob/3d3028b889c8ebbbcc14121c8e75ad1e3a7a251e/charts/library/common/values.yaml#L143).

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
