### PR TITLE
feat(common)!: Release common-3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ If you like this project, please consider supporting my work through my [GitHub 
 
 ### Discord
 
-Join the k8s-at-home [Discord](https://discord.gg/home-operations) community on Discord.
+Join the home-operations [Discord](https://discord.gg/home-operations) community on Discord.
 
 ### Repository topics
 
-Have a look at people running Kubernetes at home by checking the ["`k8s-at-home`" topic on GitHub](https://github.com/topics/k8s-at-home?o=desc&s=updated).
+Have a look at people running Kubernetes at home by checking the ["`k8s-at-home`"](https://github.com/topics/k8s-at-home?o=desc&s=updated) or ["`kubesearch`"](https://github.com/topics/kubesearch?o=desc&s=updated) on GitHub.
 
 ### Search
 
-You can use this following [search engine](https://nanne.dev/k8s-at-home-search/) provided by [@whazor](https://github.com/whazor) to search for public
+You can use the awesome [kubesearch](https://kubesearch.dev) provided by [@whazor](https://github.com/whazor) to search for public
 repositories containing any application you might wish to run.
 
 ---

--- a/charts/library/common-test/ci/advanced-values.yaml
+++ b/charts/library/common-test/ci/advanced-values.yaml
@@ -64,7 +64,7 @@ ingress:
         paths:
           - path: /
             service:
-              name: main
+              identifier: main
               port: http
     tls:
       - hosts:

--- a/charts/library/common-test/ci/basic-values.yaml
+++ b/charts/library/common-test/ci/basic-values.yaml
@@ -24,7 +24,7 @@ ingress:
         paths:
           - path: /
             service:
-              name: main
+              identifier: main
               port: http
     tls:
       - hosts:

--- a/charts/library/common-test/tests/_values/ingress_main_default_hosts.yaml
+++ b/charts/library/common-test/tests/_values/ingress_main_default_hosts.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=../../../common/values.schema.json
 ingress:
   main:
     hosts:
@@ -5,5 +7,5 @@ ingress:
         paths:
           - path: /
             service:
-              name: main
-              port: http
+              name: RELEASE-NAME
+              port: 8081

--- a/charts/library/common-test/tests/_values/service_main_default.yaml
+++ b/charts/library/common-test/tests/_values/service_main_default.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=../../../common/values.schema.json
 service:
   main:
     controller: main

--- a/charts/library/common-test/tests/ingress/presence_test.yaml
+++ b/charts/library/common-test/tests/ingress/presence_test.yaml
@@ -44,6 +44,7 @@ tests:
 
   - it: multiple ingress should pass
     values:
+      - ../_values/service_main_default.yaml
       - ../_values/ingress_main_default_hosts.yaml
     set:
       ingress.test:
@@ -52,23 +53,27 @@ tests:
             paths:
               - path: /
                 service:
-                  name: main
+                  identifier: main
                   port: http
     asserts:
       - hasDocuments:
-          count: 3
+          count: 4
       - documentIndex: 0
         not: true
         isKind:
           of: Ingress
-      - documentIndex: &FirstIngressDocument 1
+      - documentIndex: 1
+        not: true
+        isKind:
+          of: Ingress
+      - documentIndex: &FirstIngressDocument 2
         isKind:
           of: Ingress
       - documentIndex: *FirstIngressDocument
         equal:
           path: metadata.name
           value: RELEASE-NAME-main
-      - documentIndex: &SecondIngressDocument 2
+      - documentIndex: &SecondIngressDocument 3
         isKind:
           of: Ingress
       - documentIndex: *SecondIngressDocument
@@ -87,7 +92,7 @@ tests:
             paths:
               - path: /
                 service:
-                  name: main
+                  identifier: main
                   port: http
     asserts:
       - hasDocuments:

--- a/charts/library/common-test/tests/ingress/service_reference_test.yaml
+++ b/charts/library/common-test/tests/ingress/service_reference_test.yaml
@@ -52,6 +52,29 @@ tests:
               port:
                 number: 1234
 
+  - it: custom service reference with template should pass
+    set:
+      ingress.main:
+        hosts:
+          - host: chart-test.local
+            paths:
+              - path: /
+                service:
+                  name: "{{ .Release.Name }}"
+                  port: 1234
+    asserts:
+      - documentIndex: &IngressDocument 1
+        isKind:
+          of: Ingress
+      - documentIndex: *IngressDocument
+        equal:
+          path: spec.rules[0].http.paths[0].backend
+          value:
+            service:
+              name: RELEASE-NAME
+              port:
+                number: 1234
+
   - it: multiple hosts with port name references should pass
     set:
       service:
@@ -72,14 +95,14 @@ tests:
                 - path: /
                   pathType: Prefix
                   service:
-                    name: main
+                    identifier: main
                     port: http
             - host: http2.chart-test.local
               paths:
                 - path: /
                   pathType: Prefix
                   service:
-                    name: main
+                    identifier: main
                     port: http2
     asserts:
       - documentIndex: &IngressDocument 2

--- a/charts/library/common-test/tests/ingress/values_test.yaml
+++ b/charts/library/common-test/tests/ingress/values_test.yaml
@@ -6,11 +6,12 @@ templates:
 
 values:
   - ../_values/ingress_main_default_hosts.yaml
+  - ../_values/service_main_default.yaml
 
 tests:
   - it: default should pass
     asserts:
-      - documentIndex: &IngressDocument 1
+      - documentIndex: &IngressDocument 2
         isKind:
           of: Ingress
       - documentIndex: *IngressDocument
@@ -30,9 +31,9 @@ tests:
             paths:
               - path: /test
                 service:
-                  name: main
+                  identifier: main
     asserts:
-      - documentIndex: &IngressDocument 1
+      - documentIndex: &IngressDocument 2
         isKind:
           of: Ingress
       - documentIndex: *IngressDocument
@@ -52,10 +53,10 @@ tests:
             paths:
               - path: /
                 service:
-                  name: main
+                  identifier: main
                   port: http
     asserts:
-      - documentIndex: &IngressDocument 1
+      - documentIndex: &IngressDocument 2
         isKind:
           of: Ingress
       - documentIndex: *IngressDocument
@@ -71,9 +72,9 @@ tests:
             paths:
               - path: "/{{ .Release.Name }}.path"
                 service:
-                  name: main
+                  identifier: main
     asserts:
-      - documentIndex: &IngressDocument 1
+      - documentIndex: &IngressDocument 2
         isKind:
           of: Ingress
       - documentIndex: *IngressDocument
@@ -86,7 +87,7 @@ tests:
       ingress.main:
         defaultBackend: test
     asserts:
-      - documentIndex: &IngressDocument 1
+      - documentIndex: &IngressDocument 2
         isKind:
           of: Ingress
       - documentIndex: *IngressDocument

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -20,6 +20,9 @@ annotations:
     - kind: changed
       description: |-
         BREAKING: `enableServiceLinks` is now disabled by default
+    - kind: changed
+      description: |-
+        BREAKING: Referencing services under Ingress paths has been separated in explicit `name` and `identifier` keys.
     - kind: added
       description: |-
         Added support for restartPolicy field on container level. This enables Kubernetes 1.29 sidecar containers

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 3.0.0-beta4
+version: 3.0.0
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -16,16 +16,19 @@ annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: |-
-        Default objects (they used to be called main) have been commented out and will therefore no longer provide any (both expected and unexpected) default values.
+        BREAKING: Default objects (they used to be called main) have been commented out and will therefore no longer provide any (both expected and unexpected) default values.
     - kind: changed
       description: |-
-        enableServiceLinks is now disabled by default
+        BREAKING: `enableServiceLinks` is now disabled by default
     - kind: added
       description: |-
-        Added support for restartPolicy field on container level
+        Added support for restartPolicy field on container level. This enables Kubernetes 1.29 sidecar containers
+      links:
+        - name: Reference documentation
+          url: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
     - kind: added
       description: |-
-        Added json-schema to the chart
+        Added json-schema validation to the chart
     - kind: added
       description: |-
         Allow referencing secrets and configMaps by identifier in persistence section

--- a/charts/library/common/README.md
+++ b/charts/library/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 3.0.0-beta2](https://img.shields.io/badge/Version-3.0.0--beta2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for Helm charts
 
@@ -27,7 +27,7 @@ Include this chart as a dependency in your `Chart.yaml` e.g.
 # Chart.yaml
 dependencies:
   - name: common
-    version: 3.0.0-beta2
+    version: 3.0.0
     repository: https://bjw-s.github.io/helm-charts/
 ```
 
@@ -39,63 +39,15 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 
 ## Values
 
-**Important**: When deploying an application Helm chart you can add more values from the common library chart [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common)
+**Important**: When deploying an application Helm chart you can add more values from the common library chart [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common/values.yaml)
 
-The following table contains an overview of available values and their descriptions / default values.
-
-<details>
-<summary>Expand</summary>
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| configMaps | object | See below | Configure configMaps for the chart here. Additional configMaps can be added by adding a dictionary key similar to the 'config' object. |
-| controllers | object | `{}` |  |
-| defaultPodOptions | object | `{"affinity":{},"annotations":{},"automountServiceAccountToken":true,"dnsConfig":{},"dnsPolicy":"","enableServiceLinks":false,"hostAliases":[],"hostIPC":false,"hostNetwork":false,"hostPID":false,"hostname":"","imagePullSecrets":[],"labels":{},"nodeSelector":{},"priorityClassName":"","restartPolicy":"","runtimeClassName":"","schedulerName":"","securityContext":{},"terminationGracePeriodSeconds":null,"tolerations":[],"topologySpreadConstraints":[]}` | Set default options for all controllers / pods here Each of these options can be overridden on a Controller level |
-| defaultPodOptions.affinity | object | `{}` | Defines affinity constraint rules. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| defaultPodOptions.annotations | object | `{}` | Set annotations on the Pod. Pod-specific values will be merged with this. |
-| defaultPodOptions.automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
-| defaultPodOptions.dnsConfig | object | `{}` | Configuring the ndots option may resolve nslookup issues on some Kubernetes setups. |
-| defaultPodOptions.dnsPolicy | string | `""` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
-| defaultPodOptions.enableServiceLinks | bool | `false` | Enable/disable the generation of environment variables for services. [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) |
-| defaultPodOptions.hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
-| defaultPodOptions.hostIPC | bool | `false` | Use the host's ipc namespace |
-| defaultPodOptions.hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
-| defaultPodOptions.hostPID | bool | `false` | Use the host's pid namespace |
-| defaultPodOptions.hostname | string | `""` | Allows specifying explicit hostname setting |
-| defaultPodOptions.imagePullSecrets | list | `[]` | Set image pull secrets |
-| defaultPodOptions.labels | object | `{}` | Set labels on the Pod. Pod-specific values will be merged with this. |
-| defaultPodOptions.nodeSelector | object | `{}` | Node selection constraint [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
-| defaultPodOptions.priorityClassName | string | `""` | Custom priority class for different treatment by the scheduler |
-| defaultPodOptions.restartPolicy | string | `Always`. When `controller.type` is `cronjob` it defaults to `Never`. | Set Container restart policy. |
-| defaultPodOptions.runtimeClassName | string | `""` | Allow specifying a runtimeClassName other than the default one (ie: nvidia) |
-| defaultPodOptions.schedulerName | string | `""` | Allows specifying a custom scheduler name |
-| defaultPodOptions.securityContext | object | `{}` | Configure the Security Context for the Pod |
-| defaultPodOptions.terminationGracePeriodSeconds | string | `nil` | [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)] |
-| defaultPodOptions.tolerations | list | `[]` | Specify taint tolerations [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
-| defaultPodOptions.topologySpreadConstraints | list | `[]` | Defines topologySpreadConstraint rules. [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
-| global.annotations | object | `{}` | Set additional global annotations. Helm templates can be used. |
-| global.fullnameOverride | string | `nil` | Set the entire name definition |
-| global.labels | object | `{}` | Set additional global labels. Helm templates can be used. |
-| global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
-| ingress | object | `{}` | Configure the ingresses for the chart here. |
-| networkpolicies | object | See below | Configure the networkPolicies for the chart here. Additional networkPolicies can be added by adding a dictionary key similar to the 'main' networkPolicy. |
-| persistence | object | See below | Configure persistence for the chart here. Additional items can be added by adding a dictionary key similar to the 'config' key. [[ref]](https://bjw-s.github.io/helm-charts/docs/common-library/common-library-storage) |
-| route | object | See below | Configure the gateway routes for the chart here. Additional routes can be added by adding a dictionary key similar to the 'main' route. [[ref]](https://gateway-api.sigs.k8s.io/references/spec/) |
-| secrets | object | See below | Use this to populate secrets with the values you specify. Be aware that these values are not encrypted by default, and could therefore visible to anybody with access to the values.yaml file. Additional Secrets can be added by adding a dictionary key similar to the 'secret' object. |
-| service | object | See below | Configure the services for the chart here. Additional services can be added by adding a dictionary key similar to the 'main' service. |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
-| serviceAccount.labels | object | `{}` | Labels to add to the service account |
-| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| serviceMonitor | object | See below | Configure the ServiceMonitors for the chart here. Additional ServiceMonitors can be added by adding a dictionary key similar to the 'main' ServiceMonitors. |
-
-</details>
+These values will be validated by a JSON schema which can be found [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common/values.schema.json)
 
 ## Support
 
 - See the [Docs](http://bjw-s.github.io/helm-charts/docs/)
 - Open an [issue](https://github.com/bjw-s/helm-charts/issues/new/choose)
-- Join the k8s-at-home [Discord](https://discord.gg/k8s-at-home) community
+- Join the home-operations [Discord](https://discord.gg/home-operations) community
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.12.0](https://github.com/norwoodj/helm-docs/releases/v1.12.0)

--- a/charts/library/common/README.md.gotmpl
+++ b/charts/library/common/README.md.gotmpl
@@ -44,21 +44,14 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 
 ## Values
 
-**Important**: When deploying an application Helm chart you can add more values from the common library chart [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common)
+**Important**: When deploying an application Helm chart you can add more values from the common library chart [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common/values.yaml)
 
-The following table contains an overview of available values and their descriptions / default values.
-
-<details>
-<summary>Expand</summary>
-
-{{ template "chart.valuesTable" . }}
-
-</details>
+These values will be validated by a JSON schema which can be found [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common/values.schema.json)
 
 ## Support
 
 - See the [Docs](http://bjw-s.github.io/helm-charts/docs/)
 - Open an [issue](https://github.com/bjw-s/helm-charts/issues/new/choose)
-- Join the k8s-at-home [Discord](https://discord.gg/k8s-at-home) community
+- Join the home-operations [Discord](https://discord.gg/home-operations) community
 
 {{ template "helm-docs.versionFooter" . }}

--- a/charts/library/common/schemas/ingress.json
+++ b/charts/library/common/schemas/ingress.json
@@ -65,17 +65,10 @@
             },
 
             "service": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "port": {
-                  "type": ["string", "integer"]
-                }
-              },
-              "required": ["name"]
+              "oneOf": [
+                {"$ref": "#/serviceReferenceByName"},
+                {"$ref": "#/serviceReferenceByIdentifier"}
+              ]
             }
           },
           "required": ["path", "service"]
@@ -101,5 +94,33 @@
       }
     },
     "required": ["hosts"]
+  },
+
+  "serviceReferenceByName": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "port": {
+        "type": ["integer"]
+      }
+    },
+    "required": ["name", "port"]
+  },
+
+  "serviceReferenceByIdentifier": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "identifier": {
+        "type": "string"
+      },
+      "port": {
+        "type": ["string", "integer"]
+      }
+    },
+    "required": ["identifier"]
   }
 }

--- a/charts/library/common/templates/lib/ingress/_validate.tpl
+++ b/charts/library/common/templates/lib/ingress/_validate.tpl
@@ -4,12 +4,4 @@ Validate Ingress values
 {{- define "bjw-s.common.lib.ingress.validate" -}}
   {{- $rootContext := .rootContext -}}
   {{- $ingressValues := .object -}}
-
-  {{- range $ingressValues.hosts -}}
-    {{- range .paths -}}
-      {{- if empty (dig "service" "name" nil .) -}}
-        {{- fail (printf "No service name configured. (ingress: %s, path: %s)" $ingressValues.identifier .path) -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
 {{- end -}}

--- a/charts/library/common/values.schema.json
+++ b/charts/library/common/values.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/bjw-s/helm-charts/common-3.0.0-beta4/charts/library/common/values.schema.json",
+  "$id": "https://raw.githubusercontent.com/bjw-s/helm-charts/common-3.0.0/charts/library/common/values.schema.json",
 
   "type": "object",
   "properties": {

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -359,8 +359,6 @@ controllers: {}
 
 #     # -- Specify any initContainers here as dictionary items.
 #     # Each initContainer should have its own key
-#     # initContainers get sorted alphanumerically by the `<order>-<identifier>` combination
-#     # if no order or dependsOn has been configured for them.
 #     initContainers: {}
 
 serviceAccount:
@@ -521,8 +519,10 @@ ingress:
   #           pathType: Prefix
   #           service:
   #             # -- Overrides the service name reference for this path
-  #             # This can be an actual service name, or reference a service identifier from this values.yaml
+  #             # The service name to reference.
   #             name: main
+  #             # -- Reference a service identifier from this values.yaml
+  #             identifier: main
   #             # -- Overrides the service port number reference for this path
   #             port:
 


### PR DESCRIPTION
### Description of the change
Prepare the `common` library v3.0.0 release

Upgrade information can be found here: https://bjw-s.github.io/helm-charts/docs/app-template/#from-2xx-to-30x

#### Removed
<!-- Any features that have been removed -->

#### Fixed
<!-- Any functionality that has been fixed -->

#### Added
- Added support for `restartPolicy` field on container level. This will allow the use of  https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/.
- Added json-schema validation. (⚠️ see "Possible drawbacks" section)
- Allow referencing secrets and configMaps by identifier in persistence section

#### Changed
- **BREAKING 🚨**: Default objects (they used to be called `main`) have been commented out and will therefore no longer provide any (both expected and unexpected) default values.
- **BREAKING🚨**: `enableServiceLinks` is now disabled by default
- **BREAKING🚨**: Referencing services under Ingress paths has been separated in explicit `name` and `identifier` keys.

### Benefits
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
The introduction of the json schema adds additional validations and restrictions on the contents of your chart values. Things may have been missed during the initial schema creation, so if you run in to any unexpected validation errors please [raise an issue](https://github.com/bjw-s/helm-charts/issues/new?assignees=bjw-s&labels=bug&projects=&template=bug-report.md&title=).

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #233 
- fixes #266 
- fixes #206 
- fixes #123 
- fixes #281 

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->