### PR TITLE
fix(common): Fix probes intermittently choosing the wrong service

### DIFF
--- a/charts/library/common-test/tests/container/probes_test.yaml
+++ b/charts/library/common-test/tests/container/probes_test.yaml
@@ -146,6 +146,56 @@ tests:
               port: 80
             timeoutSeconds: 1
 
+  - it: multiple services should pass
+    set:
+      service:
+        other:
+          controller: other
+          ports:
+            http:
+              enabled: true
+              port: 8080
+        main:
+          controller: main
+          ports:
+            http:
+              enabled: true
+              port: &port 80
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            tcpSocket:
+              port: *port
+            timeoutSeconds: 1
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            tcpSocket:
+              port: *port
+            timeoutSeconds: 1
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            tcpSocket:
+              port: *port
+            timeoutSeconds: 1
+
   - it: disabled service should pass
     set:
       service:

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 3.0.2
+version: 3.0.3
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -16,25 +16,4 @@ annotations:
   artifacthub.io/changes: |-
     - kind: fixed
       description: |-
-        Fixed nameOverride logic to prevent duplicated name
-    - kind: changed
-      description: |-
-        BREAKING: Default objects (they used to be called main) have been commented out and will therefore no longer provide any (both expected and unexpected) default values.
-    - kind: changed
-      description: |-
-        BREAKING: `enableServiceLinks` is now disabled by default
-    - kind: changed
-      description: |-
-        BREAKING: Referencing services under Ingress paths has been separated in explicit `name` and `identifier` keys.
-    - kind: added
-      description: |-
-        Added support for restartPolicy field on container level. This enables Kubernetes 1.29 sidecar containers
-      links:
-        - name: Reference documentation
-          url: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-    - kind: added
-      description: |-
-        Added json-schema validation to the chart
-    - kind: added
-      description: |-
-        Allow referencing secrets and configMaps by identifier in persistence section
+        Fixed probes intermittently choosing the wrong service

--- a/charts/library/common/templates/lib/service/_primaryForController.tpl
+++ b/charts/library/common/templates/lib/service/_primaryForController.tpl
@@ -13,7 +13,7 @@ Return the primary service object for a controller
   {{- if $enabledServices -}}
     {{- range $name, $service := $enabledServices -}}
       {{- /* Determine the Service that has been marked as primary */ -}}
-      {{- if and (hasKey $service "primary") $service.primary -}}
+      {{- if and (eq $service.controller $controllerIdentifier) $service.primary -}}
         {{- $identifier = $name -}}
         {{- $result = $service -}}
       {{- end -}}
@@ -21,8 +21,12 @@ Return the primary service object for a controller
 
     {{- /* Return the first Service if none has been explicitly marked as primary */ -}}
     {{- if not $result -}}
-      {{- $identifier = keys $enabledServices | first -}}
-      {{- $result = get $enabledServices $identifier -}}
+      {{- range $name, $service := $enabledServices -}}
+        {{- if and (not $result) (eq $service.controller $controllerIdentifier) -}}
+          {{- $identifier = $name -}}
+          {{- $result = $service -}}
+        {{- end -}}
+      {{- end -}}
     {{- end -}}
 
     {{- include "bjw-s.common.lib.service.valuesToObject" (dict "rootContext" $rootContext "id" $identifier "values" $result) -}}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->
While upgrading from v2 to v3, I noticed probes will randomly choose service ports that use a different controller. This PR makes it so that services are only chosen for probes if they target the current controller.

#### Removed
<!-- Any features that have been removed -->

#### Fixed
<!-- Any functionality that has been fixed -->
Fixes `bjw-s.common.lib.service.primaryForController` choosing services that don't match the current controller.

#### Added
<!-- Any new features that have been added -->

#### Changed
<!-- Any features that have been changed from how they were working before -->

### Benefits
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
<!-- Describe any known limitations with your change -->

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #289

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.
