### PR TITLE
fix(common): Allow overriding checksum/configMap so we can disable restart on configmap change

### DIFF
--- a/charts/library/common-test/tests/configmap/pod_metadata_test.yaml
+++ b/charts/library/common-test/tests/configmap/pod_metadata_test.yaml
@@ -29,3 +29,29 @@ tests:
           path: spec.template.metadata.annotations
           value:
             checksum/configMaps: 66d23d7a53c4e2a523ba85a969696b4ebb78ec5d79ab9c12c210c1569f48511b
+  - it: allow overriding checksum
+    set:
+      defaultPodOptions:
+        annotations:
+          checksum/configMaps: "override"
+      configMaps:
+        config:
+          enabled: true
+          data:
+            test: value 1
+        test_default_enabled:
+          data:
+            test: value 1
+        test_disabled:
+          enabled: false
+          data:
+            test: value 1
+    asserts:
+      - documentIndex: &ControllerDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *ControllerDoc
+        equal:
+          path: spec.template.metadata.annotations
+          value:
+            checksum/configMaps: override

--- a/charts/library/common/templates/lib/pod/metadata/_annotations.tpl
+++ b/charts/library/common/templates/lib/pod/metadata/_annotations.tpl
@@ -35,8 +35,8 @@ Returns the value for annotations
   {{- end -}}
   {{- if $configMapsFound -}}
     {{- $annotations = merge
-      (dict "checksum/configMaps" (toYaml $configMapsFound | sha256sum))
       $annotations
+      (dict "checksum/configMaps" (toYaml $configMapsFound | sha256sum))
     -}}
   {{- end -}}
 


### PR DESCRIPTION
When using apps actually handle thier own config file reloads, chart should have a way to disable the changing annotations each time config maps change.

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->

#### Removed
<!-- Any features that have been removed -->

#### Fixed
Allow overriding checksum/configMap annotation

#### Added
<!-- Any new features that have been added -->

#### Changed
<!-- Any features that have been changed from how they were working before -->

### Benefits
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
<!-- Describe any known limitations with your change -->

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [ ] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.
