### PR TITLE
fix(common): Remove trim from container stdin & tty fields

### DIFF
--- a/charts/library/common-test/tests/container/field_stdin_test.yaml
+++ b/charts/library/common-test/tests/container/field_stdin_test.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: container stdin
+templates:
+  - common.yaml
+values:
+  - ../_values/controllers_main_default_container.yaml
+tests:
+  - it: default should pass
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        notExists:
+          path: spec.template.spec.containers[0].stdin
+
+  - it: custom stdin should pass
+    set:
+      controllers.main.containers:
+        main:
+          stdin: true
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].stdin
+          value: true

--- a/charts/library/common-test/tests/container/field_tty_test.yaml
+++ b/charts/library/common-test/tests/container/field_tty_test.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: container tty
+templates:
+  - common.yaml
+values:
+  - ../_values/controllers_main_default_container.yaml
+tests:
+  - it: default should pass
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        notExists:
+          path: spec.template.spec.containers[0].tty
+
+  - it: custom tty should pass
+    set:
+      controllers.main.containers:
+        main:
+          tty: true
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].tty
+          value: true

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 3.3.1
+version: 3.3.2
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -19,7 +19,7 @@ annotations:
         Added support for specifying unsupported raw resources.
     - kind: added
       description: |-
-        Added `stdin` and `tty` fields to container spec.
+        Added `stdin` and `tty` fields to container spec. (fixed in v3.3.2)
     - kind: added
       description: |-
         Added `persistentVolumeClaimRetentionPolicy` field to statefulset spec.

--- a/charts/library/common/README.md
+++ b/charts/library/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.3.2](https://img.shields.io/badge/Version-3.3.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for Helm charts
 
@@ -27,7 +27,7 @@ Include this chart as a dependency in your `Chart.yaml` e.g.
 # Chart.yaml
 dependencies:
   - name: common
-    version: 3.3.1
+    version: 3.3.2
     repository: https://bjw-s.github.io/helm-charts/
 ```
 

--- a/charts/library/common/templates/lib/container/_spec.tpl
+++ b/charts/library/common/templates/lib/container/_spec.tpl
@@ -52,10 +52,10 @@ resources: {{ toYaml . | trim | nindent 2 }}
 restartPolicy: {{ . | trim }}
   {{- end -}}
   {{- with $containerObject.stdin }}
-stdin: {{ . | trim }}
+stdin: {{ . }}
   {{- end -}}
   {{- with $containerObject.tty }}
-tty: {{ . | trim }}
+tty: {{ . }}
   {{- end -}}
   {{- with (include "bjw-s.common.lib.container.field.volumeMounts" (dict "ctx" $ctx) | trim) }}
 volumeMounts: {{ . | trim | nindent 2 }}

--- a/charts/library/common/values.schema.json
+++ b/charts/library/common/values.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/bjw-s/helm-charts/common-3.3.1/charts/library/common/values.schema.json",
+  "$id": "https://raw.githubusercontent.com/bjw-s/helm-charts/common-3.3.2/charts/library/common/values.schema.json",
 
   "type": "object",
   "properties": {


### PR DESCRIPTION
### Description of the change

Remove `trim` filter from `stdin` & `tty` fields in containers spec.

#### Fixed

Remove `trim` filter which errors while processing boolean `stdin` & `tty` fields in containers spec.

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
