### PR TITLE
feat(common): Add support for loadBalancerClass

### DIFF
--- a/charts/library/common/schemas/service.json
+++ b/charts/library/common/schemas/service.json
@@ -32,6 +32,9 @@
         "type": "array",
         "items": {"type": "string"}
       },
+      "loadBalancerClass": {
+        "type": "string"
+      },
       "externalTrafficPolicy": {
         "type": "string",
         "enum": ["Cluster", "Local"]

--- a/charts/library/common/templates/classes/_service.tpl
+++ b/charts/library/common/templates/classes/_service.tpl
@@ -49,6 +49,9 @@ spec:
   loadBalancerSourceRanges:
     {{ toYaml $serviceObject.loadBalancerSourceRanges | nindent 4 }}
   {{- end -}}
+  {{- if $serviceObject.loadBalancerClass }}
+  loadBalancerClass: {{ $serviceObject.loadBalancerClass }}
+  {{- end -}}
   {{- else if eq $svcType "ExternalName" }}
   type: {{ $svcType }}
   {{- if $serviceObject.externalName }}


### PR DESCRIPTION
### Description of the change

#### Added
Added support for setting the loadBalancerClass introduced in Kubernetes 1.24
See: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class

### Benefits
Allows multiple different types of LBs to be used. Also allows LBs that need a class to be set to be used. (e.g. Cilium Node IPAM See: https://docs.cilium.io/en/latest/network/node-ipam/ )

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.

I have not increased the chart version as I saw you're about to release 3.4.0
- [ ] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.

I have not added the variable to the values.yaml file as other variables of this depth are also not in the values yaml (e.g. loadBalancerIP)
- [ ] Variables have been documented in the `values.yaml` file.
