### PR TITLE
feat: add `hostUsers` pod field for k8s 1.29 and newer

### DIFF
--- a/charts/library/common-test/tests/pod/field_hostUsers_test.yaml
+++ b/charts/library/common-test/tests/pod/field_hostUsers_test.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: pod security
+templates:
+  - common.yaml
+values:
+  - ../_values/controllers_main_default_container.yaml
+tests:
+  # This feature requires k8s 1.29 or newer
+  - it: default should pass
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.hostUsers
+          value: true
+
+  - it: hostUsers disabled should pass
+    set:
+      defaultPodOptions:
+        hostUsers: false
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.hostUsers
+          value: false
+
+  - it: hostUsers enabled should pass
+    set:
+      defaultPodOptions:
+        hostUsers: true
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.hostUsers
+          value: true

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 3.5.1
+version: 3.5.2
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -16,4 +16,4 @@ annotations:
   artifacthub.io/changes: |-
     - kind: added
       description: |-
-        Add feature flag to override enforcing the creation of a default ServiceAccount
+        Add hostUsers field to pod spec for k8s clusters >= 1.29

--- a/charts/library/common/schemas/pod.json
+++ b/charts/library/common/schemas/pod.json
@@ -43,6 +43,10 @@
         "type": "boolean",
         "default": false
       },
+      "hostUsers": {
+        "type": "boolean",
+        "default": false
+      },
       "hostname": {
         "type": "string"
       },

--- a/charts/library/common/templates/lib/pod/_spec.tpl
+++ b/charts/library/common/templates/lib/pod/_spec.tpl
@@ -27,6 +27,9 @@ hostname: {{ . | trim }}
 hostIPC: {{ include "bjw-s.common.lib.pod.getOption" (dict "ctx" $ctx "option" "hostIPC" "default" false) }}
 hostNetwork: {{ include "bjw-s.common.lib.pod.getOption" (dict "ctx" $ctx "option" "hostNetwork" "default" false) }}
 hostPID: {{ include "bjw-s.common.lib.pod.getOption" (dict "ctx" $ctx "option" "hostPID" "default" false) }}
+  {{- if ge .Capabilities.KubeVersion.Minor 29 }}
+hostUsers: {{ include "bjw-s.common.lib.pod.getOption" (dict "ctx" $ctx "option" "hostUsers" "default" true) }}
+  {{- end -}}
 dnsPolicy: {{ include "bjw-s.common.lib.pod.field.dnsPolicy" (dict "ctx" $ctx) | trim }}
   {{- with (include "bjw-s.common.lib.pod.getOption" (dict "ctx" $ctx "option" "dnsConfig")) }}
 dnsConfig: {{ . | nindent 2 }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -48,6 +48,9 @@ defaultPodOptions:
   # -- Use the host's pid namespace
   hostPID: false
 
+  # -- Use the host's user namespace (requires 1.29 or newer)
+  hostUsers: true
+
   # -- Set image pull secrets
   imagePullSecrets: []
 


### PR DESCRIPTION
### Description of the change
This adds the [`hostUsers`](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) field when the chart is deployed to a k8s cluster that is 1.29 or newer. It defaults to `true`, k8s' default value.

#### Added
`hostUsers` field to pod spec

### Benefits
Users of the chart can now specify that pods should run in their own user namespace, rather than reusing the host user namespace. Pods can run as root with reduced risk of container escape or privilege escalation.

### Possible drawbacks
Requires k8s 1.29 or newer, as well as specific CRI versions and kernel versions. Setting this requires that several other fields (such as `hostPID`) are false.

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
