### PR TITLE
feat(common): support pullPolicy=Never in schema

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 3.6.1
+version: 3.6.2
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common
@@ -14,12 +14,6 @@ maintainers:
     email: me@bjw-s.dev
 annotations:
   artifacthub.io/changes: |-
-    - kind: fixed
+    - kind: added
       description: |-
-        Only add hostUsers when explicitly configured
-    - kind: fixed
-      description: |-
-        `hosts` should be an optional field for Ingress resources
-    - kind: fixed
-      description: |-
-        `defaultBackend` should be an object for Ingress resources
+        Allow setting pullPolicy to Never

--- a/charts/library/common/schemas/containers.json
+++ b/charts/library/common/schemas/containers.json
@@ -178,7 +178,7 @@
     "properties": {
       "pullPolicy": {
         "type": "string",
-        "enum": ["Always", "IfNotPresent"]
+        "enum": ["Always", "IfNotPresent", "Never"]
       },
       "repository": {
         "type": "string"


### PR DESCRIPTION
### Description of the change
Allow Specifying pullPolicy=Never.

### Benefits
Improve compatibility with tools like skaffold, where the container is built right before being started, and needs to not be pulled because it does not exist in any remote repository. Even specifying "IfNotPresent" can still result in some element in the chain trying to pull; which fails and halts the process of bringing the container up.
Allows more of the official/upstream options; supporting other use-cases we are both unaware of.

### Possible drawbacks
None that I am aware of.

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.

^ Did those last two in a separate commit that can be removed if schema changes are not sufficient reason to bump the version number.